### PR TITLE
LI-78: Refactor timer functionality

### DIFF
--- a/librato_python_web/instrumentor/base_instrumentor.py
+++ b/librato_python_web/instrumentor/base_instrumentor.py
@@ -28,9 +28,9 @@ from librato_python_web.instrumentor.instrument import instrument_methods
 
 
 class BaseInstrumentor(object):
-    def __init__(self, wrapped={}):
+    def __init__(self, wrapped=None):
         super(BaseInstrumentor, self).__init__()
-        self.wrapped = wrapped
+        self.wrapped = wrapped if wrapped is not None else {}
 
     def run(self):
         instrument_methods(self.wrapped)

--- a/librato_python_web/instrumentor/data/elasticsearch.py
+++ b/librato_python_web/instrumentor/data/elasticsearch.py
@@ -25,7 +25,7 @@
 
 
 from librato_python_web.instrumentor.instrument import context_function_wrapper_factory
-from librato_python_web.instrumentor.instrumentor import BaseInstrumentor
+from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor
 from librato_python_web.instrumentor.telemetry import default_instrumentation
 
 

--- a/librato_python_web/instrumentor/data/mysqldb.py
+++ b/librato_python_web/instrumentor/data/mysqldb.py
@@ -1,5 +1,5 @@
 from librato_python_web.instrumentor.instrument import context_function_wrapper_factory
-from librato_python_web.instrumentor.instrumentor import BaseInstrumentor
+from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor
 from librato_python_web.instrumentor.telemetry import default_instrumentation
 
 

--- a/librato_python_web/instrumentor/instrument.py
+++ b/librato_python_web/instrumentor/instrument.py
@@ -228,7 +228,7 @@ def generator_wrapper_factory(recorder, state=None, enable_if='web', disable_if=
     """
     Generates a function that wraps a function so that it uses the context_manager around it.
 
-    :param generator: the function used to wrap functions provided to the factory
+    :param recorder: the function used to wrap functions provided to the factory
     :param state: the state associated with the wrapped method
     :param enable_if: instrumentation is only enabled when this state is present
     :param disable_if: instrumentation is disabled when this state is present
@@ -248,19 +248,19 @@ def generator_wrapper_factory(recorder, state=None, enable_if='web', disable_if=
             if _should_be_instrumented(state, enable_if, disable_if):
                 # wrap the initialization
                 elapsed = 0
-                t = time.clock()
+                t = time.time()
                 try:
                     gen = generator(*args, **keywords)
                 finally:
-                    elapsed += time.clock() - t
+                    elapsed += time.time() - t
                 try:
                     while True:
                         # wrap each successive value generation
-                        t = time.clock()
+                        t = time.time()
                         try:
                             v = gen.next()
                         finally:
-                            elapsed += time.clock() - t
+                            elapsed += time.time() - t
                         yield v
                 finally:
                     # finish metrics (GeneratorExit or otherwise)

--- a/librato_python_web/instrumentor/log/logging.py
+++ b/librato_python_web/instrumentor/log/logging.py
@@ -1,5 +1,5 @@
 from librato_python_web.instrumentor.instrument import context_function_wrapper_factory
-from librato_python_web.instrumentor.instrumentor import BaseInstrumentor
+from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor
 from librato_python_web.instrumentor.telemetry import increment_count
 
 

--- a/librato_python_web/instrumentor/messaging/pykafka.py
+++ b/librato_python_web/instrumentor/messaging/pykafka.py
@@ -1,5 +1,5 @@
 from librato_python_web.instrumentor.instrument import context_function_wrapper_factory
-from librato_python_web.instrumentor.instrumentor import BaseInstrumentor
+from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor
 from librato_python_web.instrumentor.telemetry import default_instrumentation
 
 

--- a/librato_python_web/instrumentor/telemetry.py
+++ b/librato_python_web/instrumentor/telemetry.py
@@ -81,11 +81,11 @@ def event(event_type, dictionary=None):
 def default_instrumentation(type_name='resource'):
     @contextmanager
     def wrapper_func(*args, **keywords):
-        Timing.start_timer(type_name)
+        Timing.push_timer()
         try:
             yield
         finally:
-            elapsed = Timing.stop_timer(type_name)
+            elapsed = Timing.pop_timer()
             record_telemetry(type_name, elapsed)
 
     return wrapper_func

--- a/librato_python_web/requirements.txt
+++ b/librato_python_web/requirements.txt
@@ -1,0 +1,1 @@
+librato-metrics

--- a/test/instrumentor_/util_test.py
+++ b/test/instrumentor_/util_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2015. Librato, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Librato, Inc. nor the names of project contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL LIBRATO, INC. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import time
+from instrumentor.util import Timing
+
+
+class UtilTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_historically_named_timing(self):
+        Timing.push_timer()
+        time.sleep(0.1)
+        Timing.push_timer()
+        time.sleep(0.1)
+        self.assertAlmostEqual(0.1, Timing.pop_timer()[0], delta=0.03)
+        self.assertAlmostEqual(0.2, Timing.pop_timer()[0], delta=0.03)
+
+    def test_stack_timing(self):
+        times = 10
+
+        Timing.push_timer()
+        time.sleep(0.1)
+
+        for i in range(times):
+            Timing.push_timer()
+            time.sleep(0.1)
+            t, _ = Timing.pop_timer()
+            self.assertAlmostEqual(0.1, t, delta=0.03)
+
+        elapsed_time, net_time = Timing.pop_timer()
+
+        self.assertAlmostEqual(0.1 + times*0.1, elapsed_time, delta=0.03)
+        self.assertAlmostEqual(0.1, net_time, delta=0.03)


### PR DESCRIPTION
Moved to timer stack instead of named timers, replacing ad hoc with integral calculations. Use time.time() instead of time.clock() so that instrumentation provides wall clock measurements. Relocated BaseInstrumentor to clarify file naming.
