### PR TITLE
Round out mysqldb cursor support

### DIFF
--- a/librato_python_web/instrumentor/data/mysqldb.py
+++ b/librato_python_web/instrumentor/data/mysqldb.py
@@ -11,6 +11,9 @@ class MysqlInstrumentor(BaseInstrumentor):
                 'MySQLdb.cursors.Cursor.execute':
                     self.instrument('data.mysql.execute.', mapping={'resource': 1},
                                     state='data.mysql', disable_if='model'),
+                'MySQLdb.cursors.Cursor.callproc':
+                    self.instrument('data.mysql.callproc.', mapping={'resource': 1},
+                                    state='data.mysql', disable_if='model'),
             }
         )
 

--- a/test/instrumentor_/instrument_test.py
+++ b/test/instrumentor_/instrument_test.py
@@ -25,12 +25,12 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import unittest
-from api import context
+from librato_python_web.api import context
 
-from instrumentor.instrument import generator_wrapper_factory
-from instrumentor.telemetry import TelemetryReporter, generate_record_telemetry
+from librato_python_web.instrumentor.instrument import generator_wrapper_factory
+from librato_python_web.instrumentor.telemetry import TelemetryReporter, generate_record_telemetry
 from librato_python_web.instrumentor import instrument
-from instrumentor import telemetry
+from librato_python_web.instrumentor import telemetry
 
 
 class A(object):

--- a/test/instrumentor_/mysql_test_disabled.py
+++ b/test/instrumentor_/mysql_test_disabled.py
@@ -25,7 +25,6 @@
 
 
 import unittest
-import logging
 
 import MySQLdb
 
@@ -58,11 +57,25 @@ class ImportTest(unittest.TestCase):
             cur.execute("SELECT 1 FROM DUAL")
             cur.execute("SELECT 1 FROM DUAL")
             cur.executemany("SELECT 1 FROM DUAL", [None, None, None, None, None])
+
             # callproc
-            # execute
-            # fetchone
+
+            try:
+                cur.execute("drop procedure usercount")
+            except:
+                pass   # proc might not exist
+
+            cur.execute("create procedure usercount() begin select count(*) from mysql.user; end")
+            cur.callproc("usercount", ())
+
+            print("Fetch all - %s" % cur.fetchall())
+            cur.close()		# To avert an out of sync error
+            cur = conn.cursor()
+
+            cur.callproc("usercount", ())
+            print("Fetch one - %s" % cur.fetchone())
+
             # fetchmany
-            # fetchall
             # nextset???
 
             # tpc extensions???

--- a/test/instrumentor_/telemetry_test.py
+++ b/test/instrumentor_/telemetry_test.py
@@ -24,8 +24,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-from instrumentor.instrument import generator_wrapper_factory
-from instrumentor.telemetry import generate_record_telemetry
+from librato_python_web.instrumentor.instrument import generator_wrapper_factory
+from librato_python_web.instrumentor.telemetry import generate_record_telemetry
 
 
 class TelemetryTest(unittest.TestCase):


### PR DESCRIPTION
Add support for mysqldb cursor.callproc (which rounds out the cursor methods) and update test