### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/librato_python_web/instrumentor/instrument.py
+++ b/librato_python_web/instrumentor/instrument.py
@@ -131,7 +131,7 @@ def wrap_returned_instances(original_method, overrides):
         if hasattr(ret, '__class__'):
             # Partial ensures that wrapper method gets original method as first argument --
             # partial(func, *args, **keywords)
-            instrumented = {k: functools.partial(v, ret) for k, v in overrides.iteritems()}
+            instrumented = {k: functools.partial(v, ret) for k, v in six.iteritems(overrides)}
 
             # Create a dynamic proxy for a wrapped instance in which the instrumented methods are
             return OverrideWrapper(ret, instrumented)


### PR DESCRIPTION
`iteritems()` doesn't exist in py3, `six.iteritems()` needs to be used instead (as it is in other places in the same file).

As this completely breaks py3 use, a new release to PyPI would be appreciated — installing from git is possible, but non-trivial due to the unfortunate `.pth` magic that you're doing (`.pth` doesn't get installed by pip in that case).