### PR TITLE
Fix for pop from an empty list error

### DIFF
--- a/librato_python_web/instrumentor/context.py
+++ b/librato_python_web/instrumentor/context.py
@@ -221,8 +221,8 @@ def pop_tag():
         # e is ('route', '/v1/foo')
     :return: the entry on the top of the stack
     """
-    o = _get_stack().pop()
-    return o
+    stk = _get_stack()
+    return stk.pop() if stk else None
 
 
 def fail():

--- a/test/api_/test_context.py
+++ b/test/api_/test_context.py
@@ -52,10 +52,9 @@ class ImportTest(unittest.TestCase):
         self.assertListEqual([], get_tags())
 
     def test_pushPopTooMuch(self):
-        with self.assertRaises(IndexError):
-            push_tag('foo', 1)
-            pop_tag()
-            pop_tag()
+        push_tag('foo', 1)
+        self.assertTrue(pop_tag())
+        self.assertFalse(pop_tag())
 
     def test_set(self):
         with add_all_tags([('foo', 1)]):


### PR DESCRIPTION
Addresses the issue below, which was unsuccessful in reproducing.
   https://github.com/librato/librato-python-web/issues/34

This is a soft fix, which seems okay since tags don't propagate through the metrics pipeline yet.
Although it isn't the case here, apps can theoretically mess up the stack via the API, hence it is good to make hard assumptions about its state.