### PR TITLE
Instrument all kinds of uses in RequestsInstrumentor

### DIFF
--- a/librato_python_web/instrumentor/external/requests_.py
+++ b/librato_python_web/instrumentor/external/requests_.py
@@ -60,8 +60,8 @@ class RequestsInstrumentor(BaseInstrumentor):
         super(RequestsInstrumentor, self).__init__(
             {
                 # External calls are not recorded when in the context of a model operation
-                'requests.api.request': function_wrapper_factory(requests_request_time, state='external',
-                                                                 disable_if='model')
+                'requests.sessions.Session.send': function_wrapper_factory(requests_request_time, state='external',
+                                                                           disable_if='model')
             }
         )
 


### PR DESCRIPTION
Capturing requests.api.request covers only the most basic use of requests. Any
more complicated code is likely to use sessions or prepared requests that would
be ignored by this code. Because request() is just a thin wrapper that creates
a short-lived Session instance, it's enough to instead decorate just
requests.sessions.Session.send(), which is used by all of api.* functions,
sessions and prepared requests.