### PR TITLE
Python version constraint

### DIFF
--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -9,6 +9,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()
+        self.major_versions = [2]
         self.set_overridden(
             {
                 'psycopg2': {

--- a/librato_python_web/instrumentor/data/sqlite.py
+++ b/librato_python_web/instrumentor/data/sqlite.py
@@ -8,6 +8,7 @@ class SqliteInstrumentor(BaseInstrumentor):
 
     def __init__(self):
         super(SqliteInstrumentor, self).__init__()
+        self.major_versions = [2]
         self.set_overridden(
             {
                 'sqlite3': {

--- a/librato_python_web/instrumentor/external/urllib2_.py
+++ b/librato_python_web/instrumentor/external/urllib2_.py
@@ -143,6 +143,7 @@ class Urllib2Instrumentor(BaseInstrumentor):
                 'urllib2.OpenerDirector.open': function_wrapper_factory(_urllib2_open, disable_if='model')
             }
         )
+        self.major_versions = [2]
 
     def run(self):
         super(Urllib2Instrumentor, self).run()

--- a/test/cherrypy_/test_state.py
+++ b/test/cherrypy_/test_state.py
@@ -52,7 +52,7 @@ class StateTestCase(helper.CPWebCase):
         self.getPage('/')
         self.assertStatus(200)
 
-        states = json.loads(self.body)
+        states = json.loads(self.body.decode())
 
         self.assertEqual(len(states), 2)
         self.assertIn('web', states)


### PR DESCRIPTION
- Added ability to restrict instrumentors to a python major version
- Temporarily restricted psycopg2 and sqlite to python 3.
- Minor py3 compat fix.
