### PR TITLE
Fix for django.conf.LazySettings instrumentation issue on Python 3

### DIFF
--- a/librato_python_web/api/telemetry.py
+++ b/librato_python_web/api/telemetry.py
@@ -28,7 +28,6 @@ from contextlib import contextmanager
 from librato_python_web.instrumentor import telemetry
 
 
-
 def count(metric, incr=1):
     """
     Increment the count for the given metric by the given increment.

--- a/librato_python_web/instrumentor/bootstrap.py
+++ b/librato_python_web/instrumentor/bootstrap.py
@@ -103,7 +103,7 @@ def init(config_path=None):
 
         set_instrumentors()
         set_importer()
-        set_reporter()	# TBD: This binds the reporter to the baked-in UDP module and needs further review
+        set_reporter()	 # TBD: This binds the reporter to the baked-in UDP module and needs further review
     except:
         logger.exception("Error initializing instrumentation")
 
@@ -159,11 +159,19 @@ def import2(*args, **kwargs):
     if name in _globals.targeted_modules and name not in _globals.instrumented_modules:
         # We care about this module and it hasn't already been instrumented
 
-        logger.debug("Custom loading - %s", modname)
         instrumentor = _globals.targeted_modules[name]
 
+        # Don't proceed till required attributes are present
+        # Recursion in the module loading process can result in partially loaded modules
+        for attr_ in instrumentor.modules[name]:
+            if hasattr(mod_, attr_):
+                logger.info("Found required attribute %s in %s", attr_, name)
+            else:
+                logger.info("Skipping %s for now - missing required attr %s", name, attr_)
+                return mod_
+
         # Check off all the modules this instrumentor handles
-        _globals.instrumented_modules.update(instrumentor.modules)
+        _globals.instrumented_modules.update(instrumentor.modules.keys())
 
         try:
             logger.info("Instrumenting %s", name)

--- a/librato_python_web/instrumentor/data/elasticsearch.py
+++ b/librato_python_web/instrumentor/data/elasticsearch.py
@@ -28,7 +28,9 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class ElasticsearchInstrumentor(BaseInstrumentor):
-    modules = ['elasticsearch.client']
+    modules = {
+                  'elasticsearch.client': ['Elasticsearch']
+              }
 
     def __init__(self):
         super(ElasticsearchInstrumentor, self).__init__()

--- a/librato_python_web/instrumentor/data/mysqldb.py
+++ b/librato_python_web/instrumentor/data/mysqldb.py
@@ -2,7 +2,9 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class MysqlInstrumentor(BaseInstrumentor):
-    modules = ['MySQLdb.cursors']
+    modules = {
+                  'MySQLdb.cursors': ['Cursor']
+              }
 
     def __init__(self):
         super(MysqlInstrumentor, self).__init__()

--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -5,7 +5,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
-    modules = ['psycopg2', 'psycopg2.extensions.connection', 'psycopg2.extensions.cursor']
+    modules = {'psycopg2': []}
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()

--- a/librato_python_web/instrumentor/data/sqlite.py
+++ b/librato_python_web/instrumentor/data/sqlite.py
@@ -4,7 +4,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class SqliteInstrumentor(BaseInstrumentor):
-    modules = ['sqlite3']
+    modules = {'sqlite3': []}
 
     def __init__(self):
         super(SqliteInstrumentor, self).__init__()

--- a/librato_python_web/instrumentor/external/requests_.py
+++ b/librato_python_web/instrumentor/external/requests_.py
@@ -51,7 +51,7 @@ def requests_request_time(f):
 
 
 class RequestsInstrumentor(BaseInstrumentor):
-    modules = ['requests.sessions']
+    modules = {'requests.sessions': ['Session']}
 
     def __init__(self):
         super(RequestsInstrumentor, self).__init__(

--- a/librato_python_web/instrumentor/external/urllib2_.py
+++ b/librato_python_web/instrumentor/external/urllib2_.py
@@ -135,7 +135,7 @@ def _urllib2_open(f):
 
 
 class Urllib2Instrumentor(BaseInstrumentor):
-    modules = ['urllib2']
+    modules = {'urllib2': ['OpenerDirector']}
 
     def __init__(self):
         super(Urllib2Instrumentor, self).__init__(

--- a/librato_python_web/instrumentor/instrument.py
+++ b/librato_python_web/instrumentor/instrument.py
@@ -90,6 +90,7 @@ def instrument_methods(method_wrappers):
             logger.warn('%s not instrumented because not found', fully_qualified_class_name)
         except AttributeError:
             logger.warn('could not instrument %s', qualified_method_name)
+            logger.exception('details')
 
 
 def override_classes(overridden_classes, wrapped):

--- a/librato_python_web/instrumentor/log/logging.py
+++ b/librato_python_web/instrumentor/log/logging.py
@@ -4,7 +4,7 @@ from librato_python_web.instrumentor.telemetry import increment_count
 
 
 class LoggingInstrumentor(BaseInstrumentor):
-    modules = ['logging']
+    modules = {'logging': ['Logger']}
 
     def __init__(self):
         super(LoggingInstrumentor, self).__init__(

--- a/librato_python_web/instrumentor/messaging/pykafka.py
+++ b/librato_python_web/instrumentor/messaging/pykafka.py
@@ -2,7 +2,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class PykafkaInstrumentor(BaseInstrumentor):
-    modules = ['pykafka', 'pykafka.simpleconsumer']
+    modules = {'pykafka': ['Producer'], 'pykafka.simpleconsumer': ['SimpleConsumer']}
 
     def __init__(self):
         super(PykafkaInstrumentor, self).__init__()

--- a/librato_python_web/instrumentor/util.py
+++ b/librato_python_web/instrumentor/util.py
@@ -28,6 +28,7 @@ import base64
 from collections import OrderedDict
 import functools
 import hashlib
+import importlib
 import re
 import time
 

--- a/librato_python_web/instrumentor/web/cherrypy_.py
+++ b/librato_python_web/instrumentor/web/cherrypy_.py
@@ -77,7 +77,7 @@ def _cherrypy_wsgi_call(f):
 
 
 class CherryPyInstrumentor(BaseInstrumentor):
-    modules = ['cherrypy._cptree', 'cherrypy._cprequest']
+    modules = {'cherrypy._cptree': ['Application'], 'cherrypy._cprequest': ['Request']}
 
     def __init__(self):
         super(CherryPyInstrumentor, self).__init__(

--- a/librato_python_web/instrumentor/web/django_.py
+++ b/librato_python_web/instrumentor/web/django_.py
@@ -100,11 +100,10 @@ def _django_wsgi_call(original_method):
 
 
 class DjangoCoreInstrumentor(BaseInstrumentor):
-    modules = ['django.core.handlers.wsgi', 'django.conf']
+    modules = {'django.core.handlers.wsgi': ['WSGIHandler']}
     _wrapped = {
         'django.core.handlers.wsgi.WSGIHandler.__call__':
             function_wrapper_factory(_django_wsgi_call, state='wsgi', enable_if=None),
-        'django.conf.LazySettings.__getattr__': django_inject_middleware,
     }
 
     def __init__(self):
@@ -120,7 +119,7 @@ class DjangoCoreInstrumentor(BaseInstrumentor):
 
 
 class DjangoConfInstrumentor(BaseInstrumentor):
-    modules = ['django.conf']
+    modules = {'django.conf': ['LazySettings']}
     _wrapped = {
         'django.conf.LazySettings.__getattr__': django_inject_middleware,
     }
@@ -138,7 +137,7 @@ class DjangoConfInstrumentor(BaseInstrumentor):
 
 
 class DjangoDbInstrumentor(BaseInstrumentor):
-    modules = ['django.db.models.query']
+    modules = {'django.db.models.query': ['QuerySet']}
     _wrapped = {
         'django.db.models.query.QuerySet.iterator':
             generator_wrapper_factory(generate_record_telemetry('model.iterator.'), state='model'),

--- a/librato_python_web/instrumentor/web/flask_.py
+++ b/librato_python_web/instrumentor/web/flask_.py
@@ -96,7 +96,7 @@ def _flask_wsgi_call(f):
 
 
 class FlaskInstrumentor(BaseInstrumentor):
-    modules = ['flask.app']
+    modules = {'flask.app': ['Flask']}
 
     def __init__(self):
         super(FlaskInstrumentor, self).__init__(

--- a/librato_python_web/instrumentor/web/gunicorn_.py
+++ b/librato_python_web/instrumentor/web/gunicorn_.py
@@ -78,7 +78,7 @@ def _worker_notify(f):
 
 
 class GunicornInstrumentor(BaseInstrumentor):
-    modules = ['gunicorn.arbiter', 'gunicorn.workers.base']
+    modules = {'gunicorn.arbiter': ['Arbiter'], 'gunicorn.workers.base': ['Worker']}
 
     def __init__(self):
         super(GunicornInstrumentor, self).__init__(

--- a/test/standalone/test_gevent.py
+++ b/test/standalone/test_gevent.py
@@ -8,9 +8,8 @@ from gevent import monkey
 monkey.patch_all()
 
 import requests
-import django
 import werkzeug.serving
 
 # Ensure the patched libs are in use
-assert requests.adapters.socket.socket.__module__ == "gevent.socket", "Requests used unpatched socket"
-assert werkzeug.serving.socket.socket.__module__ == "gevent.socket", "Werkzeug used unpatched socket"
+assert 'gevent' in requests.adapters.socket.socket.__module__, "Requests used unpatched socket"
+assert 'gevent' in werkzeug.serving.socket.socket.__module__, "Werkzeug used unpatched socket"


### PR DESCRIPTION
Nested module loading sequence involving django.conf causes instrumentation to fail in the inner invocation. Reintroduced required attributes checks to resolve the issue.