### PR TITLE
Fix for psycopg2 instrumentation error on heroku with python 2.7

### DIFF
--- a/librato_python_web/instrumentor/base_instrumentor.py
+++ b/librato_python_web/instrumentor/base_instrumentor.py
@@ -56,6 +56,24 @@ class BaseInstrumentor(object):
     def set_wrapped(self, wrapped):
         self.wrapped = wrapped if wrapped is not None else {}
 
+    def can_run(self):
+        # Confirm that required modules and attributes exist
+        if hasattr(self, 'modules'):
+            for name in self.modules:
+                if name not in sys.modules:
+                    logger.info("Skipping for now - required module %s not loaded yet", name)
+                    return False
+                mod_ = sys.modules[name]
+
+                for attr_ in self.modules[name]:
+                    if hasattr(mod_, attr_):
+                        logger.info("Found required attribute %s in %s", attr_, name)
+                    else:
+                        logger.info("Skipping %s for now - missing required attr %s", name, attr_)
+                        return False
+
+        return True
+
     def run(self):
         major_version = sys.version_info[0]
         if self.major_versions and major_version not in self.major_versions:

--- a/librato_python_web/instrumentor/bootstrap.py
+++ b/librato_python_web/instrumentor/bootstrap.py
@@ -32,7 +32,7 @@ from . import general
 from . import telemetry
 from . import config
 from .telemetry import StatsdTelemetryReporter
-from .data.psycopg2 import Psycopg2Instrumentor, Psycopg2ExtensionsInstrumentor
+from .data.psycopg2 import Psycopg2Instrumentor
 from .data.sqlite import SqliteInstrumentor
 from .data.elasticsearch import ElasticsearchInstrumentor
 from .data.mysqldb import MysqlInstrumentor
@@ -59,7 +59,7 @@ _instrumentors = {
     'logging': [LoggingInstrumentor],
     'mysql': [MysqlInstrumentor],
     'sqlite': [SqliteInstrumentor],
-    'psycopg2': [Psycopg2Instrumentor, Psycopg2ExtensionsInstrumentor],
+    'psycopg2': [Psycopg2Instrumentor],
     'pykafka': [PykafkaInstrumentor],
     'requests': [RequestsInstrumentor],
     'urllib2': [Urllib2Instrumentor],

--- a/librato_python_web/instrumentor/bootstrap.py
+++ b/librato_python_web/instrumentor/bootstrap.py
@@ -164,12 +164,8 @@ def import2(*args, **kwargs):
 
         # Don't proceed till required attributes are present
         # Recursion in the module loading process can result in partially loaded modules
-        for attr_ in instrumentor.modules[name]:
-            if hasattr(mod_, attr_):
-                logger.info("Found required attribute %s in %s", attr_, name)
-            else:
-                logger.info("Skipping %s for now - missing required attr %s", name, attr_)
-                return mod_
+        if not instrumentor.can_run():
+            return mod_
 
         # Check off all the modules this instrumentor handles
         _globals.instrumented_modules.update(instrumentor.modules.keys())

--- a/librato_python_web/instrumentor/bootstrap.py
+++ b/librato_python_web/instrumentor/bootstrap.py
@@ -32,7 +32,7 @@ from . import general
 from . import telemetry
 from . import config
 from .telemetry import StatsdTelemetryReporter
-from .data.psycopg2 import Psycopg2Instrumentor
+from .data.psycopg2 import Psycopg2Instrumentor, Psycopg2ExtensionsInstrumentor
 from .data.sqlite import SqliteInstrumentor
 from .data.elasticsearch import ElasticsearchInstrumentor
 from .data.mysqldb import MysqlInstrumentor
@@ -59,7 +59,7 @@ _instrumentors = {
     'logging': [LoggingInstrumentor],
     'mysql': [MysqlInstrumentor],
     'sqlite': [SqliteInstrumentor],
-    'psycopg2': [Psycopg2Instrumentor],
+    'psycopg2': [Psycopg2Instrumentor, Psycopg2ExtensionsInstrumentor],
     'pykafka': [PykafkaInstrumentor],
     'requests': [RequestsInstrumentor],
     'urllib2': [Urllib2Instrumentor],

--- a/librato_python_web/instrumentor/bootstrap.py
+++ b/librato_python_web/instrumentor/bootstrap.py
@@ -159,6 +159,7 @@ def import2(*args, **kwargs):
     if name in _globals.targeted_modules and name not in _globals.instrumented_modules:
         # We care about this module and it hasn't already been instrumented
 
+        logger.debug("Request to load module %s", name)
         instrumentor = _globals.targeted_modules[name]
 
         # Don't proceed till required attributes are present

--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -5,7 +5,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
-    modules = {'psycopg2': ['connect']}
+    modules = {'psycopg2': ['connect'], 'psycopg2.extensions': ['connection', 'cursor']}
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()

--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -5,7 +5,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
-    modules = {'psycopg2': []}
+    modules = {'psycopg2': ['connect']}
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()

--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -5,7 +5,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
-    modules = {'psycopg2': ['connect'], 'psycopg2.extensions': ['connection', 'cursor']}
+    modules = {'psycopg2': ['connect']}
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()
@@ -18,7 +18,24 @@ class Psycopg2Instrumentor(BaseInstrumentor):
                     'connect': {
                         'returns': 'psycopg2.extensions.connection'
                     }
-                },
+                }
+            }
+        )
+
+        self.set_wrapped({})
+        super(Psycopg2Instrumentor, self).run()
+
+
+class Psycopg2ExtensionsInstrumentor(BaseInstrumentor):
+    modules = {'psycopg2.extensions': ['connection', 'cursor']}
+
+    def __init__(self):
+        super(Psycopg2ExtensionsInstrumentor, self).__init__()
+        self.major_versions = [2]
+
+    def run(self):
+        self.set_overridden(
+            {
                 'psycopg2.extensions.connection': {
                     'cursor': {
                         'returns': 'psycopg2.extensions.cursor'
@@ -52,4 +69,4 @@ class Psycopg2Instrumentor(BaseInstrumentor):
             wrapped
         )
 
-        super(Psycopg2Instrumentor, self).run()
+        super(Psycopg2ExtensionsInstrumentor, self).run()

--- a/librato_python_web/instrumentor/data/psycopg2.py
+++ b/librato_python_web/instrumentor/data/psycopg2.py
@@ -5,7 +5,7 @@ from librato_python_web.instrumentor.base_instrumentor import BaseInstrumentor, 
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
-    modules = {'psycopg2': ['connect']}
+    modules = {'psycopg2': ['connect'], 'psycopg2.extensions': ['connection', 'cursor']}
 
     def __init__(self):
         super(Psycopg2Instrumentor, self).__init__()
@@ -18,24 +18,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
                     'connect': {
                         'returns': 'psycopg2.extensions.connection'
                     }
-                }
-            }
-        )
-
-        self.set_wrapped({})
-        super(Psycopg2Instrumentor, self).run()
-
-
-class Psycopg2ExtensionsInstrumentor(BaseInstrumentor):
-    modules = {'psycopg2.extensions': ['connection', 'cursor']}
-
-    def __init__(self):
-        super(Psycopg2ExtensionsInstrumentor, self).__init__()
-        self.major_versions = [2]
-
-    def run(self):
-        self.set_overridden(
-            {
+                },
                 'psycopg2.extensions.connection': {
                     'cursor': {
                         'returns': 'psycopg2.extensions.cursor'
@@ -69,4 +52,4 @@ class Psycopg2ExtensionsInstrumentor(BaseInstrumentor):
             wrapped
         )
 
-        super(Psycopg2ExtensionsInstrumentor, self).run()
+        super(Psycopg2Instrumentor, self).run()


### PR DESCRIPTION
* Added dependencies for psycopg2
* Fixed dependency checking to cover all modules for an instrumentor, instead of just the module being loaded