### PR TITLE
Replaces "file" with "open" for py3 compatibility

### DIFF
--- a/librato_python_web/statsd/server/daemon.py
+++ b/librato_python_web/statsd/server/daemon.py
@@ -84,9 +84,9 @@ class Daemon(object):
         # Redirect file descriptors.
         sys.stdout.flush()
         sys.stderr.flush()
-        si = file(self.stdin, 'r')
-        so = file(self.stdout, 'a+')
-        se = file(self.stderr, 'a+', 0)
+        si = open(self.stdin, 'r')
+        so = open(self.stdout, 'ab')
+        se = open(self.stderr, 'ab', 0)
         os.dup2(si.fileno(), sys.stdin.fileno())
         os.dup2(so.fileno(), sys.stdout.fileno())
         os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
librato-launch-statsd fails to daemonize properly on py3.
